### PR TITLE
Add OSC support, add OSC 8 (anchor) support to the public api, add a …

### DIFF
--- a/examples/input/src/main/kotlin/main.kt
+++ b/examples/input/src/main/kotlin/main.kt
@@ -5,13 +5,23 @@ import com.varabyte.kotter.foundation.liveVarOf
 import com.varabyte.kotter.foundation.runUntilSignal
 import com.varabyte.kotter.foundation.text.*
 import com.varabyte.kotter.runtime.MainRenderScope
+import java.net.URI
 
 fun main() = session {
     // Scenario #1 - trivial but common case. A section exists to request a single input from the user
     run {
         var wantsToLearn by liveVarOf(false)
         section {
-            text("Would you like to learn "); cyan { text("Kotter") }; textLine("? (Y/n)")
+            text("Would you like to ");
+            cyan {
+                underline()
+                anchor(URI("https://github.com/varabyte/kotter"))
+                text("learn ")
+                bold()
+                text("Kotter")
+                // anchor(URI("https://github.com/varabyte/kotter"), "Kotter") << a simpler usage
+            };
+            textLine("? (Y/n)")
             text("> "); input(Completions("yes", "no"), initialText = "y")
 
             if (wantsToLearn) {

--- a/kotter/src/main/kotlin/com/varabyte/kotter/foundation/input/InputSupport.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/foundation/input/InputSupport.kt
@@ -45,7 +45,7 @@ private fun ConcurrentScopedData.prepareKeyFlow(terminal: Terminal) {
                             if (c == Ansi.CtrlChars.ESC) escSeq.clear()
 
                             escSeq.append(c)
-                            val code = Ansi.EscSeq.toCode(escSeq)
+                            val code = Ansi.EscSeq.toCsiCode(escSeq)
                             if (code != null) {
                                 escSeq.clear()
                                 when (code) {

--- a/kotter/src/main/kotlin/com/varabyte/kotter/foundation/text/OscSupport.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/foundation/text/OscSupport.kt
@@ -1,0 +1,21 @@
+package com.varabyte.kotter.foundation.text
+
+import com.varabyte.kotter.runtime.internal.ansi.commands.AnchorCommand
+import com.varabyte.kotter.runtime.render.RenderScope
+import java.net.URI
+
+/**
+ * Open an 'anchor' or hyperlink of [uri] in the current scope. Leaving the scope will close the anchor.
+ */
+fun RenderScope.anchor(uri: URI) {
+    applyCommand(AnchorCommand(uri))
+}
+
+/**
+ * Open and close an 'anchor' or hyperlink of [uri] with the given [displayText]
+ */
+fun RenderScope.anchor(uri: URI, displayText: CharSequence) {
+    applyCommand(AnchorCommand(uri))
+    text(displayText)
+    applyCommand(AnchorCommand())
+}

--- a/kotter/src/main/kotlin/com/varabyte/kotter/runtime/SectionState.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/runtime/SectionState.kt
@@ -38,6 +38,7 @@ class SectionState internal constructor(internal val parent: SectionState? = nul
         var bolded: TerminalCommand? = parentStyles?.bolded
         var struckThrough: TerminalCommand? = parentStyles?.struckThrough
         var inverted: TerminalCommand? = parentStyles?.inverted
+        var anchor: TerminalCommand? = parentStyles?.anchor
     }
 
     /** Styles which are actively applied, and any text rendered right now would use them. */
@@ -73,6 +74,10 @@ class SectionState internal constructor(internal val parent: SectionState? = nul
         if (deferred.inverted?.text !== applied.inverted?.text) {
             applied.inverted = deferred.inverted
             renderer.appendCommand(applied.inverted ?: CLEAR_INVERT_COMMAND)
+        }
+        if (deferred.anchor?.text !== applied.anchor?.text) {
+            applied.anchor = deferred.anchor
+            renderer.appendCommand(applied.anchor ?: AnchorCommand())
         }
     }
 }

--- a/kotter/src/main/kotlin/com/varabyte/kotter/runtime/internal/ansi/Ansi.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/runtime/internal/ansi/Ansi.kt
@@ -128,6 +128,7 @@ object Ansi {
             // https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
             object Sgr {
                 object RESET : Code("0${Identifiers.SGR}")
+                object RESET2 : Code("${Identifiers.SGR}")
 
                 object Decorations {
                     object BOLD : Code("1${Identifiers.SGR}")

--- a/kotter/src/main/kotlin/com/varabyte/kotter/runtime/internal/ansi/commands/AnsiCommand.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/runtime/internal/ansi/commands/AnsiCommand.kt
@@ -1,7 +1,31 @@
 package com.varabyte.kotter.runtime.internal.ansi.commands
 
+import com.varabyte.kotter.runtime.SectionState
 import com.varabyte.kotter.runtime.internal.TerminalCommand
 import com.varabyte.kotter.runtime.internal.ansi.Ansi.Csi
+import com.varabyte.kotter.runtime.internal.ansi.Ansi.Osc
+import com.varabyte.kotter.runtime.render.Renderer
+import java.net.URI
 
 internal open class AnsiCommand(ansiCode: String) : TerminalCommand(ansiCode)
 internal open class AnsiCsiCommand(csiCode: Csi.Code) : AnsiCommand(csiCode.toFullEscapeCode())
+
+internal open class AnsiOscCommand(oscCode: Osc.Code) : AnsiCommand(oscCode.toFullEscapeCode())
+
+internal open class AnchorCommand(uri: URI? = null, params: Map<String, String>? = null) :
+    AnsiOscCommand(
+        Osc.Code(
+            Osc.ANCHOR.id,
+            Osc.Code.Parts(
+                listOf(
+                    params?.map { "${it.key}=${it.value}" }?.joinToString(":") ?: "",
+                    uri?.toString() ?: "",
+                )
+            )
+        )
+    ) {
+
+    override fun applyTo(state: SectionState, renderer: Renderer<*>) {
+        state.deferred.anchor = this
+    }
+}

--- a/kotter/src/main/kotlin/com/varabyte/kotter/terminal/swing/SgrCodeConverter.kt
+++ b/kotter/src/main/kotlin/com/varabyte/kotter/terminal/swing/SgrCodeConverter.kt
@@ -62,7 +62,7 @@ private val IndexedColors by lazy {
 internal class SgrCodeConverter(val defaultForeground: Color, val defaultBackground: Color) {
     fun convert(code: Ansi.Csi.Code): (MutableAttributeSet.() -> Unit)? {
         return when(code) {
-            Ansi.Csi.Codes.Sgr.RESET -> { { removeAttributes(this) } }
+            Ansi.Csi.Codes.Sgr.RESET, Ansi.Csi.Codes.Sgr.RESET2 -> { { removeAttributes(this) } }
 
             Ansi.Csi.Codes.Sgr.Colors.Fg.CLEAR -> { { setInverseAwareForeground(defaultForeground) } }
             Ansi.Csi.Codes.Sgr.Colors.Fg.BLACK -> { { setInverseAwareForeground(AnsiColor.BLACK.toSwingColor()) } }


### PR DESCRIPTION
…simple implementation in VirtualTerminal, and use in 'input' example. Fixes #84.

Hope this is useful for you. 

Running in iTerm...

<img width="509" alt="image" src="https://user-images.githubusercontent.com/63325513/174913794-2f8ee9a5-b84e-47bb-9fbc-38e9ffbbaa6e.png">

Also see the definitive reference https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
