### PR TITLE
Grid support finished.

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.20" />
+    <option name="version" value="1.7.20" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.20" />
+    <option name="version" value="1.8.20" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,33 @@ If you want to implement your own utility method that uses `offscreen` under the
 [bordered's implementation](https://github.com/varabyte/kotter/blob/main/kotter/src/main/kotlin/com/varabyte/kotterx/decorations/BorderSupport.kt)
 yourself to see how it delegates to `offscreen`, padding each row with the right number of spaces so that the border sides all line up.
 
+### Grids
+To understand more about Grids, see: [Grid README](https://github.com/varabyte/kotter/tree/main/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md)
+
+### Simple Example
+
+```kotlin
+session {
+    section {
+        grid(width = 6, columns = 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
+            cell {
+                textLine("Cell1")
+            }
+            cell {
+                textLine("Cell2")
+            }
+
+            cell {
+                // empty cell needed for padding
+            }
+            cell {
+                textLine("Cell4")
+            }
+        }
+    }.run()
+}
+```
+
 ### 📤 Aside
 
 You can actually make one-off render requests directly inside a `run` block:

--- a/README.md
+++ b/README.md
@@ -1033,29 +1033,29 @@ If you want to implement your own utility method that uses `offscreen` under the
 yourself to see how it delegates to `offscreen`, padding each row with the right number of spaces so that the border sides all line up.
 
 ### Grids
-To understand more about Grids, see: [Grid README](https://github.com/varabyte/kotter/tree/main/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md)
-
-### Simple Example
+### Simple Examples
 
 ```kotlin
-session {
-    section {
-        grid(width = 6, columns = 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
-            cell {
-                textLine("Cell1")
-            }
-            cell {
-                textLine("Cell2")
-            }
+grid(characters = GridCharacters.BOX_THIN, Cols.uniform(2, width = 6)) {
+  cell {
+    textLine("Cell1")
+  }
+  cell {
+    textLine("Cell2")
+  }
+  
+  cell {
+    // empty cell needed for padding
+  }
+  cell {
+    textLine("Cell4")
+  }
+}
 
-            cell {
-                // empty cell needed for padding
-            }
-            cell {
-                textLine("Cell4")
-            }
-        }
-    }.run()
+grid(Cols.uniform(3, 10), paddingLeftRight = 1, defaultJustification = Justification.CENTER) {
+  cell(justification = Justification.LEFT) { textLine("Test") }
+  cell { textLine("Test") }
+  cell(justification = Justification.RIGHT) { textLine("Test") }
 }
 ```
 

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotter/foundation/render/OffscreenSupport.kt
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotter/foundation/render/OffscreenSupport.kt
@@ -26,6 +26,7 @@ typealias OffscreenRenderScope = com.varabyte.kotter.runtime.render.OffscreenRen
  */
 class OffscreenBuffer internal constructor(
     internal val parentScope: RenderScope,
+    maxWidth: Int,
     render: com.varabyte.kotter.runtime.render.OffscreenRenderScope.() -> Unit
 ) {
     private val commands = run {
@@ -42,7 +43,7 @@ class OffscreenBuffer internal constructor(
         // we want to remove both of them!
         check(offscreenRenderer.commands.takeLast(2).containsAll(listOf(NEWLINE_COMMAND, RESET_COMMAND)))
         offscreenRenderer.commands.dropLast(2)
-    }
+    }.withExplicitNewlines(maxWidth)
 
     /**
      * A property which provides access to the lengths of each line in the buffer.
@@ -61,8 +62,11 @@ class OffscreenBuffer internal constructor(
         return OffscreenCommandRenderer(parentScope, commands)
     }
 
+    fun isEmpty() = commands.isEmpty()
+
     internal fun toText() = commands.toText()
 }
+fun OffscreenBuffer.isNotEmpty() = !isEmpty()
 
 /** How many lines of text were generated within this offscreen buffer. */
 val OffscreenBuffer.numLines get() = lineLengths.size
@@ -188,5 +192,9 @@ class OffscreenCommandRenderer internal constructor(
  * See also: [justified], [bordered]
  */
 fun RenderScope.offscreen(render: com.varabyte.kotter.runtime.render.OffscreenRenderScope.() -> Unit): OffscreenBuffer {
-    return OffscreenBuffer(this, render)
+    return offscreen(Int.MAX_VALUE, render)
+}
+
+fun RenderScope.offscreen(maxWidth: Int, render: com.varabyte.kotter.runtime.render.OffscreenRenderScope.() -> Unit): OffscreenBuffer {
+    return OffscreenBuffer(this, maxWidth, render)
 }

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
@@ -1,187 +1,300 @@
 package com.varabyte.kotterx.grid
 
-import com.varabyte.kotter.foundation.render.OffscreenCommandRenderer
-import com.varabyte.kotter.foundation.render.offscreen
-import com.varabyte.kotter.foundation.text.text
-import com.varabyte.kotter.foundation.text.textLine
-import com.varabyte.kotter.runtime.Section
-import com.varabyte.kotter.runtime.concurrent.createKey
+import com.varabyte.kotter.foundation.render.*
+import com.varabyte.kotter.foundation.text.*
+import com.varabyte.kotter.runtime.render.*
 import com.varabyte.kotter.runtime.render.OffscreenRenderScope
-import com.varabyte.kotter.runtime.render.RenderScope
+import com.varabyte.kotterx.decorations.BorderCharacters.Companion.BOX_THIN
+import com.varabyte.kotterx.text.*
 import kotlin.math.min
 
-/**
- * When a `grid` block is defined, it creates this to manage state of all the child cells and `wrapText*` functions.
- */
-data class GridContext(
-    // Width of cell allowable, used in calculating how to fill a cell when empty or if not completely filled.
-    val width: Int = 20,
+class GridCharacters(
+    val horiz: Char,
+    val vert: Char,
+    val topLeft: Char,
+    val topCross: Char,
+    val topRight: Char,
+    val leftCross: Char,
+    val cross: Char,
+    val rightCross: Char,
+    val botLeft: Char,
+    val botCross: Char,
+    val botRight: Char,
+) {
+    companion object {
+        /**
+         * Grid border using basic ASCII characters guaranteed to be present in every environment.
+         *
+         * ```
+         * +-+-+
+         * | | |
+         * +-+-+
+         * | | |
+         * +-+-+
+         * ```
+         */
+        val ASCII get() = GridCharacters('-', '|', '+', '+', '+', '+', '+', '+', '+', '+', '+')
 
-    // The number of cells in a row. Once this number of cells is reached, they are rendered together to form a single
-    // "line" of output, as that is how Kotter renders to the screen.
-    val columns: Int,
+        /**
+         * Grid border using fairly standard unicode box characters.
+         *
+         * ```
+         * ┌─┬─┐
+         * │ │ │
+         * ├─┼─┤
+         * │ │ │
+         * └─┴─┘
+         * ```
+         */
 
-    // The index of the current cell within a row. Necessary for cells to know when a row is filled and when rendering
-    // of the row should begin.
-    var cellIndex: Int,
+        val BOX_THIN get() = GridCharacters('─', '│', '┌', '┬', '┐', '├', '┼', '┤', '└', '┴', '┘')
 
-    // The style to apply to the grid.
-    val gridStyle: GridStyle,
+        /**
+         * Like [BOX_THIN] but with a double-border.
+         *
+         * ```
+         * ╔═╦═╗
+         * ║ ║ ║
+         * ╠═╬═╣
+         * ║ ║ ║
+         * ╚═╩═╝
+         * ```
+         */
+        val BOX_DOUBLE get() = GridCharacters('═', '║', '╔', '╦', '╗', '╠', '╬', '╣', '╚', '╩', '╝')
 
-    // All the buffers and their line lengths that form a single row of cells. They must all be rendered "together"
-    // so the offscreen buffers won't insert newlines until after each cell appends its text to the end of the previous
-    // cell in the row.
-    var previousBuffers: MutableList<Pair<List<Int>, OffscreenCommandRenderer>> = mutableListOf(),
-)
+        /**
+         * An elegant, sleek, curved border for the sophisticated user. 🧐
+         *
+         * ```
+         * ╭─┬─╮
+         * │ │ │
+         * ├─┼─┤
+         * │ │ │
+         * ╰─┴─╯
+         * ```
+         */
+        val CURVED get() = GridCharacters('─', '│', '╭', '┬', '╮', '├', '┼', '┤', '╰', '┴', '╯')
 
-/**
- * User definable attributes about the grid to control how the cell walls and padding between cells looks.
- */
-data class GridStyle(
-
-    // Whether walls to the left and right of a cell should be drawn.
-    val leftRightWalls:Boolean = false,
-
-    // Whether walls to above and below a cell should be drawn.
-    val topBottomWalls:Boolean = false,
-
-    // how many spaces to the left and right of a cell's contents to add
-    val leftRightPadding: Int = 0,
-)
-
-const val CELL_WALL = "|"
-const val CELL_CEIL = "-"
-
-val gridContextKey = Section.Lifecycle.createKey<GridContext>()
-
-/**
- * We assume a `grid` parent was called. If not, this function will silently fail, as without a `grid` parent
- * there is no `GridContext` to define the behavior of a cell.
- */
-fun RenderScope.cell(render: OffscreenRenderScope.() -> Unit) {
-    val gridContext = data[gridContextKey] ?: return
-    val cellPos = gridContext.cellIndex
-    val columns = gridContext.columns
-    val previousBuffers = gridContext.previousBuffers
-
-    val content = offscreen(render)
-    val renderer = content.createRenderer()
-    previousBuffers.add(Pair(content.lineLengths, renderer))
-
-    if (gridContext.cellIndex == columns - 1) {
-        flushCells()
-        gridContext.cellIndex = 0
-    }
-    else {
-        gridContext.cellIndex = cellPos + 1
+        val INVISIBLE get() = GridCharacters(' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ')
     }
 }
 
-/**
- * Once a row of cells is filled, the entire row is rendered all together, interleaving all the offscreen buffers
- * together into one line, one line at a time. This enables an arbitrary number of cells to append their text
- * one after another to the offscreen buffer before newlines are inserted. This is what allows the grid to to
- * draw a grid of distinct cells.
- *
- * We assume a `grid` parent was called. If not, this function will silently fail, as without a `grid` parent
- * there is no `GridContext` to define the behavior of a cell.
- */
-fun RenderScope.flushCells() {
-    val gridContext = data[gridContextKey] ?: return
-    val previousBuffers = gridContext.previousBuffers
-    val gridStyle = gridContext.gridStyle
-    val width = gridContext.width
-    val leftRightPadding = gridStyle.leftRightPadding
-    var line = 0
+class Cols(vararg val widths: Int) {
+    private sealed class ColSpec {
+        class Fixed(val width: Int) : ColSpec()
+        class Star(val ratio: Int) : ColSpec()
+    }
 
-    while (hasNextRows(previousBuffers)) {
-        previousBuffers.forEach { buf ->
-            if (gridStyle.leftRightWalls)
-                text(CELL_WALL)
-            val renderer = buf.second
-            val lineLength = buf.first
-            if (renderer.hasNextRow()) {
-                repeat(leftRightPadding) { text(" ") }
-                renderer.renderNextRow()
-                repeat(width - lineLength[line] + leftRightPadding) { text(" ") }
-            }
-            else {
-                repeat(leftRightPadding * 2 + width) { text(" ") }
-            }
+    companion object {
+        fun uniform(count: Int, width: Int) = Cols(*IntArray(count) { width })
+
+        /**
+         * Parse a string of comma-separated column widths or "*"s.
+         *
+         * Star-sizing means that the column will take up the remaining space in the grid. If multiple different star
+         * sections exist, they will be divided up evenly based on their ratio. For example, with "2*, *", the first
+         * column will be twice as wide as the second.
+         *
+         * You can mix and match types. So "2*, 20, *" with a target width of 50 will result in columns of 20, 20, and
+         * 10.
+         *
+         * Note that the target width is used for star sizing only. If the target width is 20 and the columns are
+         * "10, 20, 30", then you'll have a table of width 60!
+         */
+        fun fromStr(str: String, targetWidth: Int? = null): Cols {
+            fun invalidPartMessage(part: String) = "Invalid column spec: $part"
+            val specs = str
+                .split(",")
+                .map { it.trim() }
+                .map { part ->
+                    if (part.endsWith("*")) {
+                        val ratio = part.dropLast(1).let {
+                            if (it.isEmpty()) 1 else it.toIntOrNull()
+                        }
+                        require(ratio != null) { invalidPartMessage(part) }
+                        ColSpec.Star(ratio)
+                    } else {
+                        val width = part.toIntOrNull()
+                        require(width != null) { invalidPartMessage(part) }
+                        ColSpec.Fixed(width)
+                    }
+                }
+
+            val starTotal = specs.sumOf { if (it is ColSpec.Star) it.ratio else 0 }
+            require(targetWidth != null || starTotal == 0) { "You must pass in a target width to `Cols.fromStr` if you use star sizing (col str = $str)" }
+            val finalWidth = targetWidth?.let {
+                it - specs.sumOf { spec -> if (spec is ColSpec.Fixed) spec.width else 0 }
+            } ?: 0
+            return Cols(*specs.map { spec ->
+                when (spec) {
+                    is ColSpec.Fixed -> spec.width
+                    is ColSpec.Star -> (finalWidth * spec.ratio) / starTotal
+                }
+            }.toIntArray())
         }
-        if (gridStyle.leftRightWalls)
-            text(CELL_WALL)
-        textLine()
-        line++
-    }
-
-    renderTopBottomCellWalls()
-
-    // clear the list so the next row of cells can fill with their buffers
-    gridContext.previousBuffers = mutableListOf()
-}
-
-/**
- * Note: will do nothing if `grid` is not a parent.
- */
-private fun RenderScope.renderTopBottomCellWalls() {
-    val gridContext = data[gridContextKey] ?: return
-    val columns = gridContext.columns
-    val gridStyle = gridContext.gridStyle
-    val width = gridContext.width
-    val leftRightPadding = gridStyle.leftRightPadding
-
-    if (gridStyle.topBottomWalls) {
-        val wallExtra = if (gridStyle.leftRightWalls) 2 else 0
-        repeat((leftRightPadding * 2 + width) * columns + wallExtra * (columns - 1)) { text(CELL_CEIL) }
-        textLine()
     }
 }
 
-private fun hasNextRows(previousBuffers: MutableList<Pair<List<Int>, OffscreenCommandRenderer>>):
-        Boolean = previousBuffers.fold(false) { anyHas, buf -> anyHas || buf.second.hasNextRow() }
+class GridScope(internal val renderScope: RenderScope, private val paddingLeftRight: Int, private val cols: Cols) {
+    private val _cellBuffers = mutableListOf<OffscreenBuffer?>()
+    internal val cellBuffers: List<OffscreenBuffer?> = _cellBuffers
+    private val _justificationOverrides = mutableMapOf<OffscreenBuffer, Justification>()
+    internal val justificationOverrides: Map<OffscreenBuffer, Justification> = _justificationOverrides
+
+    private var nextRow = 0
+    private var nextCol = 0
+
+    private fun cellIndex(row: Int, col: Int) = row * cols.widths.size + col
+
+    fun cell(justification: Justification? = null, render: OffscreenRenderScope.() -> Unit = {}) {
+        val cellIndex = cellIndex(nextRow, nextCol)
+        while (cellIndex >= cellBuffers.size) {
+            _cellBuffers.add(null)
+        }
+
+        require(cellIndex > cellBuffers.lastIndex || cellBuffers[cellIndex] == null) {
+            "Attempting to declare a grid cell in a spot that's already taken: ($nextRow, $nextCol)"
+        }
+
+        _cellBuffers[cellIndex] = renderScope.offscreen(cols.widths[nextCol] - paddingLeftRight * 2, render)
+            .also { buffer ->
+                if (justification != null) {
+                    _justificationOverrides[buffer] = justification
+                }
+            }
+
+        nextRow = cellBuffers.size / cols.widths.size
+        nextCol = cellBuffers.size % cols.widths.size
+    }
+
+    fun cell(row: Int, col: Int, justification: Justification? = null, render: OffscreenRenderScope.() -> Unit = {}) {
+        nextRow = row
+        nextCol = col
+        cell(justification, render)
+    }
+}
 
 fun RenderScope.grid(
-    width: Int,
-    columns: Int,
-    gridStyle: GridStyle = GridStyle(),
-    render: OffscreenRenderScope.() -> Unit) {
-    data[gridContextKey] = GridContext(width, columns, 0, gridStyle)
+    cols: Cols,
+    characters: GridCharacters = GridCharacters.ASCII,
+    paddingLeftRight: Int = 0,
+    paddingTopBottom: Int = 0,
+    defaultJustification: Justification = Justification.LEFT,
+    render: GridScope.() -> Unit
+) {
 
-    val content = offscreen(render)
-    val renderer = content.createRenderer()
-    renderTopBottomCellWalls()
-    while (renderer.hasNextRow()) {
-        renderer.renderNextRow()
-        textLine()
+    require(paddingLeftRight < cols.widths.min()) {
+        "Invalid LeftRight Padding or Column Spec: padding can't be wider than columns. " +
+                "Min Column: ${cols.widths.min()}, LeftRight Padding: $paddingLeftRight"
     }
 
-    // clean our cache to prevent leaks, and to prevent external `cell` instances from executing erroneously.
-    data.remove(gridContextKey)
-}
+    val gridScope = GridScope(this, paddingLeftRight, cols)
+    gridScope.render()
 
-fun RenderScope.wrapText(text: String) {
-    val width = data[gridContextKey]?.width ?: Int.MAX_VALUE
-    if (text.length > width || text.lines().size > 1) {
-        val chunks = text.length / width
-        var index = 0
-        while (index <= chunks) {
+    // Render top
+    text(characters.topLeft)
+    cols.widths.forEachIndexed { i, width ->
+        if (i > 0) text(characters.topCross)
+        text(characters.horiz.toString().repeat(width))
+    }
+    textLine(characters.topRight)
 
-            // previous lines won't write a newline, so we only do it if we broke a line
-            // and have more to process
-            if (index > 0)
-                textLine()
-            val broken = text.substring(index * width, min((index + 1) * width, text.length)).trim()
-            text(broken)
-            index++
+    val rowCount =
+        gridScope.cellBuffers.size / cols.widths.size + if (gridScope.cellBuffers.size % cols.widths.size > 0) 1 else 0
+    val lastRowIndex = rowCount - 1
+
+    for (y in 0 until rowCount) {
+        // Renderers can generate multiple lines. We need to render each line of each cell one at a time, so we create
+        // them up front and then loop through each renderer multiple times until all lines are consumed across all
+        // renderers.
+        //
+        // For example:
+        // | Single line | Multi | Multi |
+        // |             | line  | multi |
+        // |             |       | line  |
+        //
+        // ^ We need to do three passes to consume all renderers.
+
+        fun renderEmptyRow() {
+            for (x in 0 until cols.widths.size) {
+                text(characters.vert)
+                text(" ".repeat(cols.widths[x]))
+            }
+            textLine(characters.vert)
+        }
+
+        repeat(paddingTopBottom) {
+            renderEmptyRow()
+        }
+
+        val renderers = gridScope.cellBuffers
+            .subList(y * cols.widths.size, min((y + 1) * cols.widths.size, gridScope.cellBuffers.size))
+            .map { it?.createRenderer() }
+
+        if (renderers.all { it == null }) {
+            // This happens if users used `cell(row, col)` to completely skip one or more rows
+            renderEmptyRow()
+        } else {
+            var lineIndex = 0
+            while (renderers.any { it?.hasNextRow() == true }) {
+                for (x in 0 until cols.widths.size) {
+                    text(characters.vert)
+
+                    val buffer = gridScope.cellBuffers.getOrNull(y * cols.widths.size + x)?.takeIf { it.isNotEmpty() }
+                    val cellWidth = cols.widths[x] - paddingLeftRight * 2
+                    if (buffer != null) {
+                        val extraSpace = cellWidth - buffer.lineLengths.getOrElse(lineIndex) { 0 }
+                        val renderer = renderers.getOrNull(x)
+                        val justification = gridScope.justificationOverrides[buffer] ?: defaultJustification
+                        repeat(paddingLeftRight) { text(" ") }
+                        when (justification) {
+                            Justification.LEFT -> {
+                                renderer?.renderNextRow()
+                                repeat(extraSpace) { text(" ") }
+                            }
+
+                            Justification.CENTER -> {
+                                val leftSpace = extraSpace / 2
+                                val rightSpace = extraSpace - leftSpace
+                                repeat(leftSpace) { text(" ") }
+                                renderer?.renderNextRow()
+                                repeat(rightSpace) { text(" ") }
+                            }
+
+                            Justification.RIGHT -> {
+                                repeat(extraSpace) { text(" ") }
+                                renderer?.renderNextRow()
+                            }
+                        }
+                        repeat(paddingLeftRight) { text(" ") }
+                    } else {
+                        repeat(cellWidth + paddingLeftRight * 2) { text(" ") }
+                    }
+                }
+                textLine(characters.vert)
+                lineIndex++
+            }
+        }
+
+        repeat(paddingTopBottom) {
+            renderEmptyRow()
+        }
+
+        if (y < lastRowIndex) {
+            text(characters.leftCross)
+            cols.widths.forEachIndexed { i, width ->
+                if (i > 0) text(characters.cross)
+                text(characters.horiz.toString().repeat(width))
+            }
+            textLine(characters.rightCross)
         }
     }
-    else {
-        text(text)
-    }
-}
 
-fun RenderScope.wrapTextLine(text: String) {
-    wrapText(text)
-    textLine()
+    // Render bottom
+    text(characters.botLeft)
+    cols.widths.forEachIndexed { i, width ->
+        if (i > 0) text(characters.botCross)
+        text(characters.horiz.toString().repeat(width))
+    }
+    textLine(characters.botRight)
 }

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
@@ -78,9 +78,10 @@ fun RenderScope.cell(render: OffscreenRenderScope.() -> Unit) {
 }
 
 /**
- * Once a row of cells is filled, the entire row is rendered all together in interleaving all the offscreen buffers
+ * Once a row of cells is filled, the entire row is rendered all together, interleaving all the offscreen buffers
  * together into one line, one line at a time. This enables an arbitrary number of cells to append their text
- * one after another to the offscreen buffer before newlines are inserted. This is what allows the grid to
+ * one after another to the offscreen buffer before newlines are inserted. This is what allows the grid to to
+ * draw a grid of distinct cells.
  *
  * We assume a `grid` parent was called. If not, this function will silently fail, as without a `grid` parent
  * there is no `GridContext` to define the behavior of a cell.

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/GridSupport.kt
@@ -1,0 +1,186 @@
+package com.varabyte.kotterx.grid
+
+import com.varabyte.kotter.foundation.render.OffscreenCommandRenderer
+import com.varabyte.kotter.foundation.render.offscreen
+import com.varabyte.kotter.foundation.text.text
+import com.varabyte.kotter.foundation.text.textLine
+import com.varabyte.kotter.runtime.Section
+import com.varabyte.kotter.runtime.concurrent.createKey
+import com.varabyte.kotter.runtime.render.OffscreenRenderScope
+import com.varabyte.kotter.runtime.render.RenderScope
+import kotlin.math.min
+
+/**
+ * When a `grid` block is defined, it creates this to manage state of all the child cells and `wrapText*` functions.
+ */
+data class GridContext(
+    // Width of cell allowable, used in calculating how to fill a cell when empty or if not completely filled.
+    val width: Int = 20,
+
+    // The number of cells in a row. Once this number of cells is reached, they are rendered together to form a single
+    // "line" of output, as that is how Kotter renders to the screen.
+    val columns: Int,
+
+    // The index of the current cell within a row. Necessary for cells to know when a row is filled and when rendering
+    // of the row should begin.
+    var cellIndex: Int,
+
+    // The style to apply to the grid.
+    val gridStyle: GridStyle,
+
+    // All the buffers and their line lengths that form a single row of cells. They must all be rendered "together"
+    // so the offscreen buffers won't insert newlines until after each cell appends its text to the end of the previous
+    // cell in the row.
+    var previousBuffers: MutableList<Pair<List<Int>, OffscreenCommandRenderer>> = mutableListOf(),
+)
+
+/**
+ * User definable attributes about the grid to control how the cell walls and padding between cells looks.
+ */
+data class GridStyle(
+
+    // Whether walls to the left and right of a cell should be drawn.
+    val leftRightWalls:Boolean = false,
+
+    // Whether walls to above and below a cell should be drawn.
+    val topBottomWalls:Boolean = false,
+
+    // how many spaces to the left and right of a cell's contents to add
+    val leftRightPadding: Int = 0,
+)
+
+const val CELL_WALL = "|"
+const val CELL_CEIL = "-"
+
+val gridContextKey = Section.Lifecycle.createKey<GridContext>()
+
+/**
+ * We assume a `grid` parent was called. If not, this function will silently fail, as without a `grid` parent
+ * there is no `GridContext` to define the behavior of a cell.
+ */
+fun RenderScope.cell(render: OffscreenRenderScope.() -> Unit) {
+    val gridContext = data[gridContextKey] ?: return
+    val cellPos = gridContext.cellIndex
+    val columns = gridContext.columns
+    val previousBuffers = gridContext.previousBuffers
+
+    val content = offscreen(render)
+    val renderer = content.createRenderer()
+    previousBuffers.add(Pair(content.lineLengths, renderer))
+
+    if (gridContext.cellIndex == columns - 1) {
+        flushCells()
+        gridContext.cellIndex = 0
+    }
+    else {
+        gridContext.cellIndex = cellPos + 1
+    }
+}
+
+/**
+ * Once a row of cells is filled, the entire row is rendered all together in interleaving all the offscreen buffers
+ * together into one line, one line at a time. This enables an arbitrary number of cells to append their text
+ * one after another to the offscreen buffer before newlines are inserted. This is what allows the grid to
+ *
+ * We assume a `grid` parent was called. If not, this function will silently fail, as without a `grid` parent
+ * there is no `GridContext` to define the behavior of a cell.
+ */
+fun RenderScope.flushCells() {
+    val gridContext = data[gridContextKey] ?: return
+    val previousBuffers = gridContext.previousBuffers
+    val gridStyle = gridContext.gridStyle
+    val width = gridContext.width
+    val leftRightPadding = gridStyle.leftRightPadding
+    var line = 0
+
+    while (hasNextRows(previousBuffers)) {
+        previousBuffers.forEach { buf ->
+            if (gridStyle.leftRightWalls)
+                text(CELL_WALL)
+            val renderer = buf.second
+            val lineLength = buf.first
+            if (renderer.hasNextRow()) {
+                repeat(leftRightPadding) { text(" ") }
+                renderer.renderNextRow()
+                repeat(width - lineLength[line] + leftRightPadding) { text(" ") }
+            }
+            else {
+                repeat(leftRightPadding * 2 + width) { text(" ") }
+            }
+        }
+        if (gridStyle.leftRightWalls)
+            text(CELL_WALL)
+        textLine()
+        line++
+    }
+
+    renderTopBottomCellWalls()
+
+    // clear the list so the next row of cells can fill with their buffers
+    gridContext.previousBuffers = mutableListOf()
+}
+
+/**
+ * Note: will do nothing if `grid` is not a parent.
+ */
+private fun RenderScope.renderTopBottomCellWalls() {
+    val gridContext = data[gridContextKey] ?: return
+    val columns = gridContext.columns
+    val gridStyle = gridContext.gridStyle
+    val width = gridContext.width
+    val leftRightPadding = gridStyle.leftRightPadding
+
+    if (gridStyle.topBottomWalls) {
+        val wallExtra = if (gridStyle.leftRightWalls) 2 else 0
+        repeat((leftRightPadding * 2 + width) * columns + wallExtra * (columns - 1)) { text(CELL_CEIL) }
+        textLine()
+    }
+}
+
+private fun hasNextRows(previousBuffers: MutableList<Pair<List<Int>, OffscreenCommandRenderer>>):
+        Boolean = previousBuffers.fold(false) { anyHas, buf -> anyHas || buf.second.hasNextRow() }
+
+fun RenderScope.grid(
+    width: Int,
+    columns: Int,
+    gridStyle: GridStyle = GridStyle(),
+    render: OffscreenRenderScope.() -> Unit) {
+    data[gridContextKey] = GridContext(width, columns, 0, gridStyle)
+
+    val content = offscreen(render)
+    val renderer = content.createRenderer()
+    renderTopBottomCellWalls()
+    while (renderer.hasNextRow()) {
+        renderer.renderNextRow()
+        textLine()
+    }
+
+    // clean our cache to prevent leaks, and to prevent external `cell` instances from executing erroneously.
+    data.remove(gridContextKey)
+}
+
+fun RenderScope.wrapText(text: String) {
+    val width = data[gridContextKey]?.width ?: Int.MAX_VALUE
+    if (text.length > width || text.lines().size > 1) {
+        val chunks = text.length / width
+        var index = 0
+        while (index <= chunks) {
+
+            // previous lines won't write a newline, so we only do it if we broke a line
+            // and have more to process
+            if (index > 0)
+                textLine()
+            val broken = text.substring(index * width, min((index + 1) * width, text.length)).trim()
+            text(broken)
+            index++
+        }
+    }
+    else {
+        text(text)
+    }
+}
+
+fun RenderScope.wrapTextLine(text: String) {
+    wrapText(text)
+    textLine()
+}

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md
@@ -1,0 +1,98 @@
+# Grids
+Simple grid layout tools for creating arbitrary sized grids with rows and columns. With the optional use of the provided
+`wrapText` and `wrapTextLine` extension functions, styles of the text will be preserved while wrapping them to fit
+within predefined widths of the cells.
+
+## APIs
+
+`grid` - Defines the start of a grid section. Required and *must* surround all instances of *cell*
+* `width` - when using `wrapText` or `wrapTextLine`, this lets them know how long the text should be before inserting newlines.
+* `columns` - the number of cells per row. You *must* fill a row, or it will render out of order or not at all.
+* `GridStyle` - Used to control styling between cells. 
+  * `leftRightWalls` - whether walls should be printed between cells.
+  * `topBottomWalls` - whether walls should be printed above and below cells.
+  * `leftRightPadding` - how much padding between cell container and text (excluding the wall if present)
+
+`cell` - an individual container, or column within a row. Can be empty. Must be a child of `grid`
+
+`wrapText` - will constrain the length of text defined by `grid` to not exceed the `width` by adding newlines. Must
+be a child of `grid` or `cell`.
+* `text` - the text to wrap
+
+`wrapTextLine` - same as `wrapText`, but will add a newline after the last line of text.
+
+## Usage
+
+### Simple Example
+
+```kotlin
+session {
+    section {
+        grid(width = 6, columns = 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
+            cell {
+                textLine("Cell1")
+            }
+            cell {
+                textLine("Cell2")
+            }
+
+            cell {
+                // empty cell needed for padding
+            }
+            cell {
+                textLine("Cell4")
+            }
+        }
+    }.run()
+}
+```
+
+the output from the above
+
+```
+------------------
+| Cell   | Cell2  |
+------------------
+|        | Cell4  |
+------------------
+```
+
+### Explanation
+`grid` performs appropriate setup for the offscreen buffer and final rendering of the child cells. `cell` is defining a
+single container of the grid, much like a row and column in a table. Note the usage of an empty third cell. When using
+grids, all rows must be "full" or they won't render correctly. Likewise, if a row doesn't need a cell in a given
+position, it is OK to use empty cells. They will fill the entire container with spaces to ensure proper sizing.
+
+### Styling Example
+Grids can use styling within cells, and other Kotter primitives.
+
+```kotlin
+grid(width = 6, columns = 2) {
+    cell {
+        textLine("Cell1")
+    }
+    cell {
+        yellow {
+            textLine("Cell2")
+        }
+    }
+
+    bold {
+        cell {
+            // empty cell needed for padding
+        }
+        cell {
+            textLine("Cell4")
+        }
+    }
+}
+```
+
+## Future Work
+* Customizable walls, including colors.
+* word wrapping
+* multi-width cells
+* multi-height cells
+* nested tables
+* top-bottom padding
+* suggestions?

--- a/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md
+++ b/kotter/src/commonMain/kotlin/com/varabyte/kotterx/grid/README.md
@@ -1,25 +1,7 @@
 # Grids
-Simple grid layout tools for creating arbitrary sized grids with rows and columns. With the optional use of the provided
-`wrapText` and `wrapTextLine` extension functions, styles of the text will be preserved while wrapping them to fit
-within predefined widths of the cells.
+Simple grid layout tools for creating arbitrary sized grids with rows and columns.
 
-## APIs
-
-`grid` - Defines the start of a grid section. Required and *must* surround all instances of *cell*
-* `width` - when using `wrapText` or `wrapTextLine`, this lets them know how long the text should be before inserting newlines.
-* `columns` - the number of cells per row. You *must* fill a row, or it will render out of order or not at all.
-* `GridStyle` - Used to control styling between cells. 
-  * `leftRightWalls` - whether walls should be printed between cells.
-  * `topBottomWalls` - whether walls should be printed above and below cells.
-  * `leftRightPadding` - how much padding between cell container and text (excluding the wall if present)
-
-`cell` - an individual container, or column within a row. Can be empty. Must be a child of `grid`
-
-`wrapText` - will constrain the length of text defined by `grid` to not exceed the `width` by adding newlines. Must
-be a child of `grid` or `cell`.
-* `text` - the text to wrap
-
-`wrapTextLine` - same as `wrapText`, but will add a newline after the last line of text.
+You specify the number of columns explicitly; rows are auto added as you declare new grid cells.
 
 ## Usage
 
@@ -28,20 +10,13 @@ be a child of `grid` or `cell`.
 ```kotlin
 session {
     section {
-        grid(width = 6, columns = 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
-            cell {
-                textLine("Cell1")
-            }
-            cell {
-                textLine("Cell2")
-            }
-
-            cell {
-                // empty cell needed for padding
-            }
-            cell {
-                textLine("Cell4")
-            }
+        grid(Cols.uniform(2, width = 6), leftRightPadding = 1) {
+            cell { textLine("Cell1") }
+            cell { textLine("Cell2") }
+            cell() // Skip over empty cell
+            cell { textLine("Cell4") }
+            // Alternately, `cell(row = 1, col = 1) { textLine("Cell4") }`
+            // and no need to specify the empty cell
         }
     }.run()
 }
@@ -56,43 +31,3 @@ the output from the above
 |        | Cell4  |
 ------------------
 ```
-
-### Explanation
-`grid` performs appropriate setup for the offscreen buffer and final rendering of the child cells. `cell` is defining a
-single container of the grid, much like a row and column in a table. Note the usage of an empty third cell. When using
-grids, all rows must be "full" or they won't render correctly. Likewise, if a row doesn't need a cell in a given
-position, it is OK to use empty cells. They will fill the entire container with spaces to ensure proper sizing.
-
-### Styling Example
-Grids can use styling within cells, and other Kotter primitives.
-
-```kotlin
-grid(width = 6, columns = 2) {
-    cell {
-        textLine("Cell1")
-    }
-    cell {
-        yellow {
-            textLine("Cell2")
-        }
-    }
-
-    bold {
-        cell {
-            // empty cell needed for padding
-        }
-        cell {
-            textLine("Cell4")
-        }
-    }
-}
-```
-
-## Future Work
-* Customizable walls, including colors.
-* word wrapping
-* multi-width cells
-* multi-height cells
-* nested tables
-* top-bottom padding
-* suggestions?

--- a/kotter/src/commonTest/kotlin/com/varabyte/kotterx/grid/GridSupportTest.kt
+++ b/kotter/src/commonTest/kotlin/com/varabyte/kotterx/grid/GridSupportTest.kt
@@ -4,15 +4,52 @@ import com.varabyte.kotter.foundation.text.*
 import com.varabyte.kotter.runtime.internal.ansi.*
 import com.varabyte.kotterx.test.foundation.*
 import com.varabyte.kotterx.test.terminal.*
+import com.varabyte.kotterx.text.*
 import com.varabyte.truthish.assertThat
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
 
 class GridSupportTest {
+    @Test
+    fun `you can set cell row and col values explicitly`() = testSession { terminal ->
+        section {
+            grid(Cols(1, 1)) {
+                cell { textLine("X") }
+                cell { textLine("Y") }
+                // Out of order
+                cell(1, 1) { textLine("Z") }
+                cell(1, 0) { textLine("A") }
+                // Next cell automatically finds next slot after last filled in cell
+                cell { textLine("B") }
+                cell { textLine("C") }
+                // You can skip multiple rows
+                cell(5, 1) { textLine("!") }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "+-+-+",
+            "|X|Y|",
+            "+-+-+",
+            "|A|Z|",
+            "+-+-+",
+            "|B|C|",
+            "+-+-+",
+            "| | |",
+            "+-+-+",
+            "| | |",
+            "+-+-+",
+            "| |!|",
+            "+-+-+",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
 
     @Test
-    fun `single cell grid works`() = testSession { terminal ->
+    fun `col size larger than width works`() = testSession { terminal ->
         section {
-            grid(4, 1) {
+            grid(Cols(6)) {
                 cell {
                     textLine("Test")
                 }
@@ -20,42 +57,128 @@ class GridSupportTest {
         }.run()
 
         assertThat(terminal.lines()).containsExactly(
-            "Test",
+            "+------+",
+            "|Test  |",
+            "+------+",
             Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
         ).inOrder()
     }
 
     @Test
-    fun `single cell grid of text works`() = testSession { terminal ->
+    fun `smaller widths break up cell contents`() = testSession { terminal ->
         section {
-            grid(4, 1) {
-                cell {
-                    text("Test")
-                }
-            }
-        }.run()
-
-        assertThat(terminal.lines()).containsExactly(
-            "Test",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
-    }
-
-    @Test
-    fun `two cell grid with larger width than text works`() = testSession { terminal ->
-        section {
-            grid(6, 2) {
+            grid(Cols(2, 5)) {
                 cell {
                     textLine("Test")
                 }
                 cell {
-                    textLine("Test2")
+                    textLine("Test 2")
                 }
             }
         }.run()
 
         assertThat(terminal.lines()).containsExactly(
-            "Test  Test2 ",
+            "+--+-----+",
+            "|Te|Test |",
+            "|st|2    |",
+            "+--+-----+",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `missing last cell gets filled in automatically`() = testSession { terminal ->
+        section {
+            grid(cols = Cols.uniform(2, width = 7)) {
+                cell {
+                    textLine("Test 11")
+                }
+                cell {
+                    textLine("Test 12")
+                }
+                cell {
+                    textLine("Test 21")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "+-------+-------+",
+            "|Test 11|Test 12|",
+            "+-------+-------+",
+            "|Test 21|       |",
+            "+-------+-------+",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `can change grid border characters`() = testSession { terminal ->
+        section {
+            grid(characters = GridCharacters.BOX_THIN, cols = Cols.uniform(2, width = 7)) {
+                cell {
+                    textLine("Test 11")
+                }
+                cell {
+                    textLine("Test 12")
+                }
+                cell {
+                    textLine("Test 21")
+                }
+                cell {
+                    textLine("Test 22")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "┌───────┬───────┐",
+            "│Test 11│Test 12│",
+            "├───────┼───────┤",
+            "│Test 21│Test 22│",
+            "└───────┴───────┘",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `Cols fromStr can create column widths`() = testSession { terminal ->
+        section {
+            grid(cols = Cols.fromStr("3*, 4, 1*", 12)) {
+                cell {
+                    textLine("A")
+                }
+                cell {
+                    textLine("B")
+                }
+                cell {
+                    textLine("C")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "+------+----+--+",
+            "|A     |B   |C |",
+            "+------+----+--+",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `justification works`() = testSession { terminal ->
+        section {
+            grid(Cols.uniform(3, 10), paddingLeftRight = 1, defaultJustification = Justification.CENTER) {
+                cell(justification = Justification.LEFT) { textLine("Test") }
+                cell { textLine("Test") }
+                cell(justification = Justification.RIGHT) { textLine("Test") }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "+----------+----------+----------+",
+            "| Test     |   Test   |     Test |",
+            "+----------+----------+----------+",
             Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
         ).inOrder()
     }
@@ -63,7 +186,7 @@ class GridSupportTest {
     @Test
     fun `two cell grid with multiple textLine works`() = testSession { terminal ->
         section {
-            grid(6, 2) {
+            grid(Cols.uniform(2, 6)) {
                 cell {
                     textLine("Test")
                     textLine("Test")
@@ -77,189 +200,68 @@ class GridSupportTest {
         }.run()
 
         assertThat(terminal.lines()).containsExactly(
-            "Test  Test  ",
-            "Test  Test  ",
-            "Test        ",
+            "+------+------+",
+            "|Test  |Test  |",
+            "|Test  |Test  |",
+            "|Test  |      |",
+            "+------+------+",
             Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
         ).inOrder()
     }
 
     @Test
-    fun `two by two cell grid with multiple text works`() = testSession { terminal ->
+    fun `padding works`() = testSession { terminal ->
         section {
-            grid(6, 2) {
-                cell {
-                    text("Test")
-                    text("12")
-                }
-                cell {
-                    text("Test")
-                    text("12")
-                }
-
-                cell {
-                    text("Test")
-                    text("12")
-                }
-                cell {
-                    text("Test")
-                    text("12")
-                }
+            grid(Cols(5, 5), paddingLeftRight = 2, paddingTopBottom = 1) {
+                cell { textLine("X") }
+                cell { textLine("YZ") }
             }
         }.run()
 
         assertThat(terminal.lines()).containsExactly(
-            "Test12Test12",
-            "Test12Test12",
+            "+-----+-----+",
+            "|     |     |",
+            "|  X  |  Y  |",
+            "|     |  Z  |",
+            "|     |     |",
+            "+-----+-----+",
             Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
         ).inOrder()
     }
 
     @Test
-    fun `two by two cell grid with larger width than text works`() = testSession { terminal ->
+    fun `padding with smaller col widths fails`() = testSession { terminal ->
         section {
-            grid(6, 2) {
-                cell {
-                    textLine("Test")
-                }
-                cell {
-                    textLine("Test2")
-                }
-
-                cell {
-                    textLine("Test3")
-                }
-                cell {
-                    textLine("Test4")
-                }
+            grid(Cols(2, 2), paddingLeftRight = 4) {
+                cell { textLine("A") }
+                cell { textLine("B") }
             }
         }.run()
 
-        assertThat(terminal.lines()).containsExactly(
-            "Test  Test2 ",
-            "Test3 Test4 ",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
+        assertThat(terminal.lines()).containsExactly("").inOrder()
     }
 
     @Test
-    fun `two by two cell grid with larger width than textLine works`() = testSession { terminal ->
+    fun `invalid star widths fails`() = testSession { terminal ->
         section {
-            grid(6, 2) {
-                cell {
-                    textLine("Test")
-                }
-                cell {
-                    textLine("Test2")
-                }
-
-                cell {
-                    textLine("Test3")
-                }
-                cell {
-                    textLine("Test4")
-                }
+            grid(Cols.fromStr("*")) {
+                cell { textLine("A") }
+                cell { textLine("B") }
             }
         }.run()
 
-        assertThat(terminal.lines()).containsExactly(
-            "Test  Test2 ",
-            "Test3 Test4 ",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
+        assertThat(terminal.lines()).containsExactly("").inOrder()
     }
 
     @Test
-    fun `3 columns with 3 rows grid with empty cells works`() = testSession { terminal ->
+    fun `non-integer star widths fails`() = testSession { terminal ->
         section {
-            grid(6, 3) {
-                cell {
-                    textLine("Test")
-                }
-                cell {
-                    textLine("Test2")
-                }
-                cell {
-
-                }
-
-                cell {
-                    textLine("Test3")
-                }
-                cell {
-
-                }
-                cell {
-                    textLine("Test4")
-                }
+            grid(Cols.fromStr("*sdf")) {
+                cell { textLine("A") }
+                cell { textLine("B") }
             }
         }.run()
 
-        assertThat(terminal.lines()).containsExactly(
-            "Test  Test2       ",
-            "Test3       Test4 ",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
-    }
-
-    @Test
-    fun `two by two cell grid with walls and padding and larger width than textLine works`() = testSession { terminal ->
-        section {
-            grid(6, 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
-                cell {
-                    textLine("Test")
-                }
-                cell {
-                    textLine("Test2")
-                }
-
-                cell {
-                    textLine("Test3")
-                }
-                cell {
-                    textLine("Test4")
-                }
-            }
-        }.run()
-
-        assertThat(terminal.lines()).containsExactly(
-            "------------------",
-            "| Test   | Test2  |",
-            "------------------",
-            "| Test3  | Test4  |",
-            "------------------",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
-    }
-
-    @Test
-    fun `two by two cell grid with everything works`() = testSession { terminal ->
-        section {
-            grid(8, 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
-                cell {
-                    wrapTextLine("TestTestTestTest")
-                }
-                cell {
-                    textLine("Test2")
-                }
-
-                cell {
-                    textLine("Test3")
-                }
-                cell {
-                    textLine("Test4")
-                }
-            }
-        }.run()
-
-        assertThat(terminal.lines()).containsExactly(
-            "----------------------",
-            "| TestTest | Test2    |",
-            "| TestTest |          |",
-            "----------------------",
-            "| Test3    | Test4    |",
-            "----------------------",
-            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
-        ).inOrder()
+        assertThat(terminal.lines()).containsExactly("").inOrder()
     }
 }

--- a/kotter/src/commonTest/kotlin/com/varabyte/kotterx/grid/GridSupportTest.kt
+++ b/kotter/src/commonTest/kotlin/com/varabyte/kotterx/grid/GridSupportTest.kt
@@ -1,0 +1,265 @@
+package com.varabyte.kotterx.grid
+
+import com.varabyte.kotter.foundation.text.*
+import com.varabyte.kotter.runtime.internal.ansi.*
+import com.varabyte.kotterx.test.foundation.*
+import com.varabyte.kotterx.test.terminal.*
+import com.varabyte.truthish.assertThat
+import kotlin.test.Test
+
+class GridSupportTest {
+
+    @Test
+    fun `single cell grid works`() = testSession { terminal ->
+        section {
+            grid(4, 1) {
+                cell {
+                    textLine("Test")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `single cell grid of text works`() = testSession { terminal ->
+        section {
+            grid(4, 1) {
+                cell {
+                    text("Test")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two cell grid with larger width than text works`() = testSession { terminal ->
+        section {
+            grid(6, 2) {
+                cell {
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test2")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test  Test2 ",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two cell grid with multiple textLine works`() = testSession { terminal ->
+        section {
+            grid(6, 2) {
+                cell {
+                    textLine("Test")
+                    textLine("Test")
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test")
+                    textLine("Test")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test  Test  ",
+            "Test  Test  ",
+            "Test        ",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two by two cell grid with multiple text works`() = testSession { terminal ->
+        section {
+            grid(6, 2) {
+                cell {
+                    text("Test")
+                    text("12")
+                }
+                cell {
+                    text("Test")
+                    text("12")
+                }
+
+                cell {
+                    text("Test")
+                    text("12")
+                }
+                cell {
+                    text("Test")
+                    text("12")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test12Test12",
+            "Test12Test12",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two by two cell grid with larger width than text works`() = testSession { terminal ->
+        section {
+            grid(6, 2) {
+                cell {
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test2")
+                }
+
+                cell {
+                    textLine("Test3")
+                }
+                cell {
+                    textLine("Test4")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test  Test2 ",
+            "Test3 Test4 ",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two by two cell grid with larger width than textLine works`() = testSession { terminal ->
+        section {
+            grid(6, 2) {
+                cell {
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test2")
+                }
+
+                cell {
+                    textLine("Test3")
+                }
+                cell {
+                    textLine("Test4")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test  Test2 ",
+            "Test3 Test4 ",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `3 columns with 3 rows grid with empty cells works`() = testSession { terminal ->
+        section {
+            grid(6, 3) {
+                cell {
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test2")
+                }
+                cell {
+
+                }
+
+                cell {
+                    textLine("Test3")
+                }
+                cell {
+
+                }
+                cell {
+                    textLine("Test4")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "Test  Test2       ",
+            "Test3       Test4 ",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two by two cell grid with walls and padding and larger width than textLine works`() = testSession { terminal ->
+        section {
+            grid(6, 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
+                cell {
+                    textLine("Test")
+                }
+                cell {
+                    textLine("Test2")
+                }
+
+                cell {
+                    textLine("Test3")
+                }
+                cell {
+                    textLine("Test4")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "------------------",
+            "| Test   | Test2  |",
+            "------------------",
+            "| Test3  | Test4  |",
+            "------------------",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+
+    @Test
+    fun `two by two cell grid with everything works`() = testSession { terminal ->
+        section {
+            grid(8, 2, GridStyle(leftRightWalls = true, topBottomWalls = true, leftRightPadding = 1)) {
+                cell {
+                    wrapTextLine("TestTestTestTest")
+                }
+                cell {
+                    textLine("Test2")
+                }
+
+                cell {
+                    textLine("Test3")
+                }
+                cell {
+                    textLine("Test4")
+                }
+            }
+        }.run()
+
+        assertThat(terminal.lines()).containsExactly(
+            "----------------------",
+            "| TestTest | Test2    |",
+            "| TestTest |          |",
+            "----------------------",
+            "| Test3    | Test4    |",
+            "----------------------",
+            Ansi.Csi.Codes.Sgr.RESET.toFullEscapeCode(),
+        ).inOrder()
+    }
+}


### PR DESCRIPTION
Grids have been added to Kotter, enabling the use of arbitrary sized table-like organization of text. These extensions are compatible with existing primitives, with some further additions for necessities like `wrapText` and `wrapTextLine` for better presentation of grids.

Unit tests have also been provided to cover some of the basic forms of grids that users might try to create.

Note: There is a significant drawback with the current implementation. When the user defines `columns`, then there must be that many cells present in *every* row. If not, then two failures will happen. Cells may appear out of order depending on where the missing cell is, and the last row will never render.

As a workaround, empty cells have been tested to work just fine, and should be used to ensure every row is filled.