### PR TITLE
Changes Kross shell needed form kotter: expose read calls, user configurable sigint handling

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jdk-22" project-jdk-type="JavaSDK" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="corretto-19" project-jdk-type="JavaSDK" />
 </project>

--- a/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
+++ b/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
@@ -21,7 +21,9 @@ import kotlin.system.exitProcess
 /**
  * A [Terminal] implementation which interacts directly with the underlying system terminal.
  */
-class SystemTerminal(private val onCtrlC: () -> Unit = { exitProcess(130) }) : Terminal {
+class SystemTerminal(
+  private val onCtrlC: () -> Unit = { exitProcess(130) } // 130 == 128+2, where 2 == SIGINT
+) : Terminal {
     private var previousCursorSetting: InfoCmp.Capability
     private val previousOut = System.out
     private val previousErr = System.err
@@ -42,7 +44,7 @@ class SystemTerminal(private val onCtrlC: () -> Unit = { exitProcess(130) }) : T
 
             // Handle Ctrl-C ourselves, because Windows otherwise swallows it
             // See also: https://github.com/jline/jline3/issues/822
-            handle(Signal.INT) { onCtrlC() } // 130 == 128+2, where 2 == SIGINT
+            handle(Signal.INT) { onCtrlC() } 
 
             val disabledPrintStream = PrintStream(object : OutputStream() {
                 override fun write(b: Int) = Unit

--- a/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
+++ b/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
@@ -21,7 +21,7 @@ import kotlin.system.exitProcess
 /**
  * A [Terminal] implementation which interacts directly with the underlying system terminal.
  */
-class SystemTerminal : Terminal {
+class SystemTerminal(private val onCtrlC: () -> Unit = { exitProcess(130) }) : Terminal {
     private var previousCursorSetting: InfoCmp.Capability
     private val previousOut = System.out
     private val previousErr = System.err
@@ -42,7 +42,7 @@ class SystemTerminal : Terminal {
 
             // Handle Ctrl-C ourselves, because Windows otherwise swallows it
             // See also: https://github.com/jline/jline3/issues/822
-            handle(Signal.INT) { exitProcess(130) } // 130 == 128+2, where 2 == SIGINT
+            handle(Signal.INT) { onCtrlC() } // 130 == 128+2, where 2 == SIGINT
 
             val disabledPrintStream = PrintStream(object : OutputStream() {
                 override fun write(b: Int) = Unit

--- a/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
+++ b/kotter/src/jvmMain/kotlin/com/varabyte/kotter/terminal/system/SystemTerminal.kt
@@ -74,6 +74,8 @@ class SystemTerminal : Terminal {
         terminal.writer().flush()
     }
 
+    fun read(timeout: Long) = terminal.reader().read(timeout)
+
     private val charFlow: SharedFlow<Int> by lazy {
         flow {
             var quit = false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Only in settings.gradle in modern Gradle
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.6.0")
+}
 rootProject.name = "kotter"
 
 include(":kotter")


### PR DESCRIPTION
The kross shell needs a strong guarantee that it will not call read again if it is about to open a child process. All shells handle ctrl-c themselves so I need my own handling there too.

The toolchain resolver is just because I am too lazy to setup jdk11 just for kotter, so gradle does it for me with this plugin